### PR TITLE
Fix admin console

### DIFF
--- a/app/admin/apps.rb
+++ b/app/admin/apps.rb
@@ -9,6 +9,7 @@ ActiveAdmin.register App do
     column :current_sign_in_at
     column :sign_in_count
     column :created_at
+    column :discarded_at
     actions
   end
 
@@ -19,6 +20,7 @@ ActiveAdmin.register App do
   filter :created_at
 
   form do |f|
+    f.semantic_errors
     f.inputs do
       f.input :name
       f.input :description

--- a/app/controllers/tokens_controller.rb
+++ b/app/controllers/tokens_controller.rb
@@ -10,7 +10,7 @@ class TokensController < Doorkeeper::TokensController
     headers.merge! response.headers
     self.response_body = response.body.to_json
     self.status = response.status
-  rescue Errors::DoorkeeperError => e
+  rescue Doorkeeper::Errors::DoorkeeperError => e
     handle_token_exception e
   end
 

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -20,10 +20,23 @@ class App < ApplicationRecord
     false
   end
 
+  def discard
+    super
+    @existing_token = Doorkeeper::AccessToken.find_by(resource_owner_id: id, revoked_at: nil)
+    if @existing_token
+      @existing_token.revoked_at = Time.current
+      @existing_token.save
+    end
+  end
+
   class << self
     def authenticate(name, password)
       app = App.find_for_authentication(name: name)
-      app.try(:valid_password?, password) ? app : nil
+      if app.discarded?
+        nil
+      else
+        app.try(:valid_password?, password) ? app : nil
+      end
     end
   end
 end

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -32,7 +32,7 @@ class App < ApplicationRecord
   class << self
     def authenticate(name, password)
       app = App.find_for_authentication(name: name)
-      if app.discarded?
+      if app.nil? || app.discarded?
         nil
       else
         app.try(:valid_password?, password) ? app : nil

--- a/app/models/app.rb
+++ b/app/models/app.rb
@@ -7,6 +7,7 @@ class App < ApplicationRecord
          :recoverable, :rememberable, :trackable, :validatable,
          authentication_keys: [:name]
 
+  validates :name, presence: true, uniqueness: true
   def email_required?
     false
   end

--- a/spec/controllers/tokens_controller_spec.rb
+++ b/spec/controllers/tokens_controller_spec.rb
@@ -31,6 +31,23 @@ RSpec.describe TokensController, type: :controller do
     end
   end
 
+  describe "POST #token discarded app" do
+    it "returns a unauthorized response" do
+      @expected = wrong_credentials_response
+      unauthorized_app = create(:app)
+      unauthorized_app.discard
+      unauthorized_app.reload
+      @app_params = {
+        "password": unauthorized_app.password,
+        "name": unauthorized_app.name
+      }
+      post :create, params: @app_params
+      expect(response.body).to look_like_json
+      expect(response).to be_unauthorized
+      expect(parsed_response).to match(@expected)
+    end
+  end
+
   describe "POST #revoke" do
     it "returns a success response" do
       token = controller_login


### PR DESCRIPTION
## Description
- Fixed admin console bugs: 
Name should validate for presence
Name should validate for uniqueness, should not show "An unhandled lowlevel error occurred. The application logs may have details."
After discarding app, apps still able to use old access tokens to interact with api
- Task numbers:
154654426