### PR TITLE
Used env vars for QA env instead

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -18,15 +18,12 @@
 # Environmental secrets are only available for that specific environment.
 
 predefined: &predefined
-  secret_key_base: 464a1c93948dacf5ff7c7bd29085a02b3091bb87c369101c85371c1c29adf9efde49b3d22ffe99929cb1bfaf8603d1c4999f9f12955192ffd845c057c421adb8
+  secret_key_base: some-key-here
 
 development:
   <<: *predefined
 
 test:
-  <<: *predefined
-
-qa:
   <<: *predefined
 
 # Do not keep production secrets in the unencrypted secrets file.
@@ -37,6 +34,9 @@ qa:
 dynamic: &dynamic
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
 
+qa:
+  <<: *dynamic
+  
 ci_test:
   <<: *dynamic
 


### PR DESCRIPTION
## Description
- Remove secret-key-base plaintext value for QA. Use env variables instead.


